### PR TITLE
Remove the tarball file after it has been expanded

### DIFF
--- a/lib/mina-circle/tasks.rb
+++ b/lib/mina-circle/tasks.rb
@@ -30,6 +30,7 @@ namespace :circleci do
     puts "[mina-circle] Fetching: #{circle_artifact}"
     queue "curl -o #{circle_artifact} #{build_url}"
     queue "#{circle_explode_command} #{circle_artifact}"
+    queue "rm #{circle_artifact}"
   end
 end
 


### PR DESCRIPTION
This resolves issue #20, by deleting the tarball on the server after it has been expanded. 