### PR TITLE
feat: add support for circle ci 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@
 A plugin for [Mina](https://github.com/mina-deploy/mina) to deploy pre-built
 artifacts from CircleCI.
 
-Current Version 1.4.0 - Now supports circle ci version 2.0 workflows!
+
+[![Gem](https://img.shields.io/gem/v/mina-circle.svg)](https://github.com/sparkbox/mina-circle)
+
+Now supports CircleCI version 2.0 Workflows!
 
 ## Why?
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A plugin for [Mina](https://github.com/mina-deploy/mina) to deploy pre-built
 artifacts from CircleCI.
 
-Current Version 1.3.5
+Current Version 1.4.0 - Now supports circle ci version 2.0 workflows!
 
 ## Why?
 

--- a/lib/mina-circle/circle-ci/project.rb
+++ b/lib/mina-circle/circle-ci/project.rb
@@ -13,19 +13,33 @@ class CircleCI::Project
   end
 
   def api_path
+    api_path_parts.join('/')
+  end
+
+  def build_path
+    parts = api_path_parts + ['tree', real_branch]
+      
+    parts.compact.join('/')
+  end
+
+  private
+
+  def api_path_parts
     [
       'project',
       vcs_type,
       organization,
       name
-    ].join('/')
+    ]
   end
 
-  private
+  def real_branch
+    branch || 'master'
+  end
 
   def fetch_artifacts
     # To support Circle 2.0
-    build_info = CircleCI::Client.instance.get "#{api_path}", filter: 'successful', branch: branch ? branch : 'master', has_artifacts: true
+    build_info = CircleCI::Client.instance.get "#{build_path}", filter: 'successful', has_artifacts: true
 
     build_num = 'latest' # circle version 1.0
 
@@ -35,7 +49,7 @@ class CircleCI::Project
 
     puts "Using Build: #{build_num}"
 
-    artifact_hashes = CircleCI::Client.instance.get "#{api_path}/#{build_num}/artifacts", filter: 'successful', branch: branch ? branch : 'master'
+    artifact_hashes = CircleCI::Client.instance.get "#{api_path}/#{build_num}/artifacts", filter: 'successful', branch: real_branch
     artifact_hashes.collect { |artifact_hash|
       CircleCI::Artifact.new artifact_hash
     }

--- a/lib/mina-circle/circle-ci/project.rb
+++ b/lib/mina-circle/circle-ci/project.rb
@@ -24,7 +24,18 @@ class CircleCI::Project
   private
 
   def fetch_artifacts
-    artifact_hashes = CircleCI::Client.instance.get "#{api_path}/latest/artifacts", filter: 'successful', branch: branch ? branch : 'master'
+    # To support Circle 2.0
+    build_info = CircleCI::Client.instance.get "#{api_path}", filter: 'successful', branch: branch ? branch : 'master', has_artifacts: true
+
+    build_num = 'latest' # circle version 1.0
+
+    if build_info.first['previous_successful_build']['build_num']
+      build_num = build_info.first['previous_successful_build']['build_num']
+    end
+
+    puts "Using Build: #{build_num}"
+
+    artifact_hashes = CircleCI::Client.instance.get "#{api_path}/#{build_num}/artifacts", filter: 'successful', branch: branch ? branch : 'master'
     artifact_hashes.collect { |artifact_hash|
       CircleCI::Artifact.new artifact_hash
     }

--- a/lib/mina-circle/version.rb
+++ b/lib/mina-circle/version.rb
@@ -1,3 +1,3 @@
 module MinaCircle
-  VERSION = '1.3.5'
+  VERSION = '1.4.0'
 end

--- a/test/mina-circle/circle-ci/test_project.rb
+++ b/test/mina-circle/circle-ci/test_project.rb
@@ -5,4 +5,9 @@ class TestProject < Minitest::Test
     project = CircleCI::Project.new organization: 'foo', name: 'bar', branch: 'master'
     assert_equal 'project/github/foo/bar', project.api_path
   end
+
+  def test_build_path
+    project = CircleCI::Project.new organization: 'foo', name: 'bar', branch: 'master'
+    assert_equal 'project/github/foo/bar/tree/master', project.build_path
+  end
 end


### PR DESCRIPTION
Add support for circle ci 2.0 workflows by obtaining the latest build number from the circle api.
This is backwards compatible as long as the API version is 1.1 (v1.1)

This will resolve #41 