### PR TITLE
fix: Tolerate projects which are missing workflows

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mina-circle (2.0.0)
+    mina-circle (2.0.1)
       mina (~> 0.3, >= 0.3.0)
 
 GEM
@@ -23,4 +23,4 @@ DEPENDENCIES
   rake (~> 10.4, >= 10.4.0)
 
 BUNDLED WITH
-   1.16.2
+   1.17.2

--- a/lib/mina-circle/circle-ci/build.rb
+++ b/lib/mina-circle/circle-ci/build.rb
@@ -1,7 +1,7 @@
 class CircleCI::Build
   attr_reader :job_name, :build_number, :status, :project
   def initialize(hash, project)
-    @job_name = hash['workflows']['job_name']
+    @job_name = hash.dig 'workflows', 'job_name'
     @build_number = hash['build_num']
     @status = hash['status']
     @project = project

--- a/lib/mina-circle/helpers.rb
+++ b/lib/mina-circle/helpers.rb
@@ -14,6 +14,11 @@ module MinaCircle
           .select { |build| build.status == 'success' && build.job_name == settings[:circleci_job_name] }
           .sort { |a, b| a.build_number <=> b.build_number }
 
+      if successful_for_job.empty?
+        STDERR.puts 'No successful builds for this branch and job name'
+        exit 1
+      end
+
       build_artifacts = successful_for_job.last.artifacts
 
       deploy_artifact = build_artifacts.find { |artifact| artifact.filename == settings[:circleci_artifact] }

--- a/lib/mina-circle/version.rb
+++ b/lib/mina-circle/version.rb
@@ -1,3 +1,3 @@
 module MinaCircle
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end


### PR DESCRIPTION
Mina Circle can now instantiate a build instance when the workflow property is missing. Deploy attempts now fail with a helpful message when a successful build does not exist for a given branch and job name combination. These changes do not support deploying without a workflow job name, though that might be possible with more changes.