### PR TITLE
add message about missing token

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mina-circle (2.0.1)
+    mina-circle (2.0.2)
       mina (~> 0.3, >= 0.3.0)
 
 GEM
@@ -10,7 +10,7 @@ GEM
     mina (0.3.8)
       open4 (~> 1.3.4)
       rake
-    minitest (5.8.3)
+    minitest (5.14.0)
     open4 (1.3.4)
     rake (10.5.0)
 

--- a/lib/mina-circle/circle-ci/client.rb
+++ b/lib/mina-circle/circle-ci/client.rb
@@ -9,6 +9,10 @@ class CircleCI::Client
   include Singleton
   BASE_URI = 'https://circleci.com/api/v1.1'
   CONFIG_FILE_PATH = File.join(Dir.home, '.mina-circle.yml')
+  unless File.exists?(CONFIG_FILE_PATH)
+    puts "Please follow the setup steps (https://github.com/sparkbox/mina-circle#setup) and create a token."
+    exit
+  end
   attr_writer :api_token
 
   def get(path, params = {})

--- a/lib/mina-circle/version.rb
+++ b/lib/mina-circle/version.rb
@@ -1,3 +1,3 @@
 module MinaCircle
-  VERSION = '2.0.1'
+  VERSION = '2.0.2'
 end


### PR DESCRIPTION
The error around a missing API token are not immediately obvious and require an understanding of how the project works. This adds a helpful console message plus it enforces reading the README again.