### PR TITLE
Upgrade to mina 1.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
     mina (0.3.8)
       open4 (~> 1.3.4)
       rake
-    minitest (5.8.3)
+    minitest (5.14.4)
     open4 (1.3.4)
     rake (13.0.3)
 
@@ -19,7 +19,7 @@ PLATFORMS
 
 DEPENDENCIES
   mina-circle!
-  minitest (~> 5.8, >= 5.8.0)
+  minitest (>= 5.8.0)
   rake (>= 12.3.3)
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: .
   specs:
-    mina-circle (2.0.1)
-      mina (~> 0.3, >= 0.3.0)
+    mina-circle (3.0.0.beta.1)
+      mina (~> 1.2)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    mina (0.3.8)
+    mina (1.2.3)
       open4 (~> 1.3.4)
       rake
     minitest (5.14.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
       rake
     minitest (5.8.3)
     open4 (1.3.4)
-    rake (10.5.0)
+    rake (13.0.3)
 
 PLATFORMS
   ruby
@@ -20,7 +20,7 @@ PLATFORMS
 DEPENDENCIES
   mina-circle!
   minitest (~> 5.8, >= 5.8.0)
-  rake (~> 10.4, >= 10.4.0)
+  rake (>= 12.3.3)
 
 BUNDLED WITH
    1.17.2

--- a/lib/mina-circle/helpers.rb
+++ b/lib/mina-circle/helpers.rb
@@ -1,7 +1,7 @@
 require 'uri'
 module MinaCircle
   module Helpers
-    def artifact_fetch_command
+    def artifact_fetch_command(settings)
       project = CircleCI::Project.new(
         organization: settings[:circleci_user],
         name: settings[:circleci_project]

--- a/lib/mina-circle/tasks.rb
+++ b/lib/mina-circle/tasks.rb
@@ -18,25 +18,46 @@ extend MinaCircle::Helpers
 # Command with options for decompressing the artifact archive
 
 namespace :mina_circle do
+
+  def required_settings
+    [ 
+      :circleci_artifact,
+      :circleci_user,
+      :circleci_project,
+      :circleci_job_name,
+      :circleci_explode_command,
+      :branch,
+    ]
+  end
+
+  def ensure_and_fetch!(setting_name)
+    ensure!(setting_name)
+    fetch(setting_name)
+    end
+
+  required_settings.each do |required_setting|
+    define_method required_setting do
+      ensure_and_fetch! required_setting
+    end
+  end
+
   desc 'Downloads and explodes the archive file containing the build'
   task :deploy do
+    required_settings.each &method(:ensure!)
 
-    if !circleci_artifact
-      print_error "[mina-circle] You must specify a `circleci_artifact`"
-      die
-    end
-    if !circleci_user
-      print_error "[mina-circle] You must specify a `circleci_user`"
-      die
-    end
-    if !circleci_project
-      print_error "[mina-circle] You must specify a `circleci_project`"
-      die
-    end
+    options = {
+      circleci_user: circleci_user,
+      circleci_project: circleci_project,
+      branch: branch,
+      circleci_job_name: circleci_job_name,
+      circleci_artifact: circleci_artifact,
+    }
 
-    print_str "[mina-circle] Fetching: #{circleci_artifact}"
-    queue echo_cmd(artifact_fetch_command)
-    queue echo_cmd("#{circleci_explode_command} #{circleci_artifact}")
-    queue echo_cmd("rm #{circleci_artifact}")
+    comment "[mina-circle] Fetching: #{circleci_artifact}"
+    command artifact_fetch_command(options)
+
+    command "#{circleci_explode_command} #{circleci_artifact}"
+
+    command "rm #{circleci_artifact}"
   end
 end

--- a/lib/mina-circle/version.rb
+++ b/lib/mina-circle/version.rb
@@ -1,3 +1,3 @@
 module MinaCircle
-  VERSION = '2.0.1'
+  VERSION = '3.0.0.beta.1'
 end

--- a/mina-circle.gemspec
+++ b/mina-circle.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'mina', '~> 0.3', '>= 0.3.0'
   s.add_development_dependency 'rake', '>= 12.3.3'
-  s.add_development_dependency 'minitest', '~> 5.8', '>= 5.8.0'
+  s.add_development_dependency 'minitest', '>= 5.8.0'
 end

--- a/mina-circle.gemspec
+++ b/mina-circle.gemspec
@@ -4,15 +4,15 @@ Gem::Specification.new do |s|
   s.name = 'mina-circle'
   s.version = MinaCircle::VERSION
   s.summary = 'Deploy your application from artifacts produced by CircleCI'
-  s.authors = ['Patrick Simpson', 'Michael Yockey']
-  s.email = ['patrick@heysparkbox.com', 'mike@heysparkbox.com']
+  s.authors = ['Patrick Simpson', 'Michael Yockey', 'Ryan Cromwell']
+  s.email = ['ryan@heysparkbox.com']
   s.licenses = ['MIT']
   s.description = 'Deploy without dependancies using mina and CircleCI.'
   s.files = Dir.glob('lib/**/*')
   s.require_path = 'lib'
   s.homepage = 'https://github.com/sparkbox/mina-circle'
 
-  s.add_runtime_dependency 'mina', '~> 0.3', '>= 0.3.0'
+  s.add_runtime_dependency 'mina', '~> 1.2'
   s.add_development_dependency 'rake', '>= 12.3.3'
   s.add_development_dependency 'minitest', '>= 5.8.0'
 end

--- a/mina-circle.gemspec
+++ b/mina-circle.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/sparkbox/mina-circle'
 
   s.add_runtime_dependency 'mina', '~> 0.3', '>= 0.3.0'
-  s.add_development_dependency 'rake', '~> 10.4', '>= 10.4.0'
+  s.add_development_dependency 'rake', '>= 12.3.3'
   s.add_development_dependency 'minitest', '~> 5.8', '>= 5.8.0'
 end

--- a/test/config/deploy.rb
+++ b/test/config/deploy.rb
@@ -1,0 +1,45 @@
+require 'mina/deploy'
+require 'mina-circle'
+
+# require 'mina/rbenv'  # for rbenv support. (https://rbenv.org)
+# require 'mina/rvm'    # for rvm support. (https://rvm.io)
+
+# Basic settings:
+#   domain       - The hostname to SSH to.
+#   deploy_to    - Path to deploy into.
+#   repository   - Git repo to clone from. (needed by mina/git)
+#   branch       - Branch name to deploy. (needed by mina/git)
+
+set :application_name, 'foobar'
+set :domain, '23.253.162.16'
+set :user, 'sparkuser'
+set :repository, 'https://github.com/sparkbox/tirediscounters.git'
+set :deploy_to, '/var/www/vhosts/foobar.com'
+set :branch, 'main'
+
+set :circleci_user, 'sparkbox'
+set :circleci_project, 'tirediscounters'#example-circle-project'
+set :circleci_job_name, 'create_sparkboxqa_artifact'#`default-job'
+set :circleci_artifact, 'tirediscounters-dist-docker.tar.gz'#example-dist.tar.gz'
+set :circleci_explode_command, 'tar -mzxf'
+
+# Optional settings:
+#   set :user, 'foobar'          # Username in the server to SSH to.
+#   set :port, '30000'           # SSH port number.
+#   set :forward_agent, true     # SSH forward_agent.
+
+# Shared dirs and files will be symlinked into the app-folder by the 'deploy:link_shared_paths' step.
+# Some plugins already add folders to shared_dirs like `mina/rails` add `public/assets`, `vendor/bundle` and many more
+# run `mina -d` to see all folders and files already included in `shared_dirs` and `shared_files`
+# set :shared_dirs, fetch(:shared_dirs, []).push('public/assets')
+# set :shared_files, fetch(:shared_files, []).push('config/database.yml', 'config/secrets.yml')
+
+
+desc "Deploys the current version to the server."
+task :deploy do
+  run(:local){ invoke :'mina_circle:deploy' }
+end
+
+# For help in making your deploy script, see the Mina documentation:
+#
+#  - https://github.com/mina-deploy/mina/tree/master/docs


### PR DESCRIPTION
Couple things going on here:

1. Upgrading to more recent versions of minitest and rake. Mina is built on rake, so this goes along with the second item.
2. Upgrades mina to the latest version, [1.2.3](https://github.com/mina-deploy/mina/tree/v1.2.3).
3. Applies the idiomatic mina DSL as seen in `lib/mina-circle/tasks.rb`.
4. Creates an test deploy script in `test/config/deploy.rb`. 

**Idiomatic Mina DSL**
Mina has eliminated some of the dynamic helpers such as `print_str`, getters for variables, etc. Some of the things you will see in the mina-circle task implementation are:

* [`required_settings`](https://github.com/sparkbox/mina-circle/compare/upgrade-mina?expand=1#diff-c4d4989a5296a29d744d11459db074d5ff7219da2dfa3844fef9caa459b77e77R22) as a list of symbols representing the settings a consuming deploy should have set.
* [Dynamically defined getter methods](https://github.com/sparkbox/mina-circle/compare/upgrade-mina?expand=1#diff-c4d4989a5296a29d744d11459db074d5ff7219da2dfa3844fef9caa459b77e77R38-R40) for each required setting that will `ensure!` and `fetch` the setting.
* [Short circuit validation](https://github.com/sparkbox/mina-circle/compare/upgrade-mina?expand=1#diff-c4d4989a5296a29d744d11459db074d5ff7219da2dfa3844fef9caa459b77e77R46) of each of the `required_settings`

**Test Deploy Script**
If you `cd test`, you can run `mina deploy` and it will locally run `mina-circle`. For this PR, it is pointing at Tire Discounters. This is a baby step to a full integration test that I _think_ we can run in CircleCI.

Before committing this PR, those settings should be replaced with placeholders, but I'll leave them for ease of testing for now.